### PR TITLE
Merge overloaded IDL method definitions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -126,22 +126,24 @@ div.enum-description > table > thead > tr > th {
     </div>
 
   <h3 id="autoplay-detection-methods">The Autoplay Detection Methods</h3>
+    <pre class="idl">
+      callback HTMLMediaElementConstructor = HTMLMediaElement ();
+      callback AudioContextConstructor = AudioContext ();
+
+      [Exposed=Window]
+      partial interface Navigator {
+        AutoplayPolicy getAutoplayPolicy(HTMLMediaElementConstructor mediaCtor);
+        AutoplayPolicy getAutoplayPolicy(AudioContextConstructor audioCtor);
+        AutoplayPolicy getAutoplayPolicy(HTMLMediaElement element);
+        AutoplayPolicy getAutoplayPolicy(AudioContext context);
+      };
+    </pre>
+
     <h4 id="query-by-a-constructor">Query by a Constructor</h4>
-      <pre class="idl">
-        callback HTMLMediaElementConstructor = HTMLMediaElement ();
-        callback AudioContextConstructor = AudioContext ();
-
-        [Exposed=Window]
-        partial interface Navigator {
-          AutoplayPolicy getAutoplayPolicy(HTMLMediaElementConstructor ctor);
-
-          AutoplayPolicy getAutoplayPolicy(AudioContextConstructor ctor);
-        };
-      </pre>
-
-      This represents a rough status of whether media, which have the same type
+      The {{getAutoplayPolicy(mediaCtor)}} and {{getAutoplayPolicy(audioCtor)}}
+      methods return the rough status of whether media, which have the same type
       of the queried constructor and exist in the {{document}} contained in the
-      {{Window}} object asscociated with the queried {{Navigator}} object, are
+      {{Window}} object associated with the queried {{Navigator}} object, are
       allowed to autoplay or not. The media terms appearing in the next
       following if-statement have the same definition as above description.
 
@@ -211,16 +213,9 @@ div.enum-description > table > thead > tr > th {
     </div>
 
   <h4 id="query-by-a-element">Query by an Element</h3>
-    <pre class="idl">
-      [Exposed=Window]
-      partial interface Navigator {
-        AutoplayPolicy getAutoplayPolicy(HTMLMediaElement element);
-
-        AutoplayPolicy getAutoplayPolicy(AudioContext context);
-      };
-    </pre>
-    This represents the current status of whether the queried element is
-    allowed to autoplay or not.
+    The {{getAutoplayPolicy(element)}} and {{getAutoplayPolicy(context)}}
+    methods return the current status of whether the queried element is allowed
+    to autoplay or not.
 
     <dl class="switch">
       <dt>If the value is {{allowed}}</dt>


### PR DESCRIPTION
Web IDL forbids overloaded operations across partial interfaces definitions:
"Operations must not be overloaded across interface, partial interface, interface mixin, and partial interface mixin definitions"
https://webidl.spec.whatwg.org/#idl-overloading

In practice, that means that all `getAutoplay` methods must be defined within the same partial interface definition. This update merges the previous two IDL blocks into one, and references the right methods in the prose.

@alastor0325 This reuses the same argument names as in #19. Hapy to update the PR if we end up with different names.