### PR TITLE
[meta] Enable auto-publish to TR

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -30,3 +30,7 @@ jobs:
         uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages
+          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          W3C_WG_DECISION_URL: https://github.com/w3c/media-wg/issues/27
+          W3C_BUILD_OVERRIDE: |
+            status: WD

--- a/index.bs
+++ b/index.bs
@@ -1,12 +1,13 @@
 <pre class='metadata'>
 Title: Autoplay Policy Detection
 Shortname: autoplay-detection
-Level: 1
+Level: None
 Status: w3c/ED
 Group: mediawg
 Repository: https://github.com/w3c/autoplay
 URL: https://w3c.github.io/autoplay/
-Editor: Alastor Wu, Mozilla https://www.mozilla.org, alwu@mozilla.com
+TR: https://www.w3.org/TR/autoplay-detection/
+Editor: Alastor Wu, Mozilla https://www.mozilla.org, alwu@mozilla.com, w3cid 92198
 Abstract: This specification provides web developers the ability to detect if automatically starting the playback of a media file is allowed in different situations.
 Markup Shorthands: markdown on
 </pre>


### PR DESCRIPTION
This update adds needed parameters to the auto-publish job for it to take care of publication to https://www.w3.org/TR/ as well, following publication of the spec as [First Public Working Draft](https://www.w3.org/TR/2022/WD-autoplay-detection-20220315/).

It also updates the spec metadata to add the missing w3cid for the editor, the /TR URL, and drop the level to stick to an `autoplay-detection` shortname for now. This can be changed later on if group decides that a level-based approach is needed.

Note that the Echidna token referenced in the job was added to the repository settings as secret.

I'm creating the PR as draft for now as I suspect it should only be merged starting tomorrow: there is, I believe, no way to publish a regular Working Draft on the same day as the First Public Working Draft.