### PR TITLE
Improve a11y by providing explicit descriptive headers for enums.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -83,8 +83,10 @@ div.enum-description > table > thead > tr > th {
     <table class="simple" dfn-for="AutoplayPolicy" dfn-type="enum-value">
       <thead>
         <tr>
-          <th scope="col" colspan="2">
-            Enumeration description
+          <tr>
+            <th scope="col">Enum Value</th>
+            <th scope="col">Description</th>
+          </tr>
       <tbody>
         <tr>
           <td>
@@ -149,8 +151,10 @@ div.enum-description > table > thead > tr > th {
       <table class="simple" dfn-for="AutoplayPolicyMediaType" dfn-type="enum-value">
         <thead>
           <tr>
-            <th scope="col" colspan="2">
-              Enumeration description
+          <tr>
+            <th scope="col">Enum Value</th>
+            <th scope="col">Description</th>
+          </tr>
         <tbody>
           <tr>
             <td>

--- a/index.bs
+++ b/index.bs
@@ -83,8 +83,10 @@ div.enum-description > table > thead > tr > th {
     <table class="simple" dfn-for="AutoplayPolicy" dfn-type="enum-value">
       <thead>
         <tr>
-          <th scope="col" colspan="2">
-            Enumeration description
+          <th scope="col">Enum Value</th>
+          <th scope="col">Description</th>
+        </tr>
+      </thead>
       <tbody>
         <tr>
           <td>
@@ -149,8 +151,10 @@ div.enum-description > table > thead > tr > th {
       <table class="simple" dfn-for="AutoplayPolicyMediaType" dfn-type="enum-value">
         <thead>
           <tr>
-            <th scope="col" colspan="2">
-              Enumeration description
+            <th scope="col">Enum Value</th>
+            <th scope="col">Description</th>
+          </tr>
+        </thead>
         <tbody>
           <tr>
             <td>


### PR DESCRIPTION
See https://github.com/w3c/autoplay/issues/32#issuecomment-1119133154.